### PR TITLE
Clarify authorize vs sign

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -162,10 +162,9 @@ the key being used to sign the content and the authorized entity) to
 verify that a message was signed by that entity.
    </t>
    <t>
-When optionally combined with asymmetric keys in certificates issued
-via PKI, this specification can also enable authentication of a client and
-server with no prior knowledge of each other via a trusted CA issuing their
-respective certificates.
+When optionally combined with asymmetric keys associated with an
+identity, this specification can also enable authentication of a client and
+server with or without no prior knowledge of each other.
    </t>
   </section>
 

--- a/index.xml
+++ b/index.xml
@@ -123,14 +123,17 @@ altered during transmission or storage in a way that alters the meaning expresse
 in the original message as signed. Any party reading the message (the verifier)
 may independently confirm the validity of the message signature. This scheme
 is agnostic to the client/server direction and can be used to verify the contents of
-either HTTP requests, HTTP reponses or both.
+either HTTP requests, HTTP reponses, or both.
        </t>
        <t>
 The "Authorization" scheme which is intended primarily to allow a sender
-to assert an identity and request access to a resource or resources. This is
-typically used in authentication flows such as OAuth2, and as a consequence
-`Authorization` header is normally generated (and the message signed) by the
-HTTP client and the message verified by an HTTP service.
+to request access to a resource or resources by proving their identity. This
+specification allows for this both with a shared secret (using HMAC) or with
+public/private keys. The "Authorization" scheme is
+typically used in authentication processes and not directly for message signing.
+As a consequence `Authorization` header is normally generated
+(and the message signed) by the HTTP client and the message verified by
+the HTTP server.
        </t>
      </list>
   </t>
@@ -152,7 +155,7 @@ Digital signatures are widely used to provide authentication and integrity
 assurances without
 the need for shared secrets. They also do not require a round-trip in
 order to authenticate the client, and allow the integrity of a message to
-be verified independently of the transport (e.g. TLS)
+be verified independently of the transport (e.g. TLS).
 A server need only have an understanding of the key (e.g. through
 a mapping between
 the key being used to sign the content and the authorized entity) to
@@ -274,7 +277,7 @@ MUST be ignored.
    <t>
 A signed HTTP message needs to be tolerant of some
 alterations during transmission
-as it goes through gateways, proxies and other entities. As such, the raw
+as it goes through gateways, proxies, and other entities. As such, the raw
 HTTP message transmitted by the signer, and the HTTP message received
 by the verifier may have undergone some changes, typically in the form of
 added, removed or altered headers. These changes are not normally under the

--- a/index.xml
+++ b/index.xml
@@ -159,7 +159,7 @@ the key being used to sign the content and the authorized entity) to
 verify that a message was signed by that entity.
    </t>
    <t>
-When optionally combined with keys in certificates issued
+When optionally combined with asymmetric keys in certificates issued
 via PKI, this specification can also enable authentication of a client and
 server with no prior knowledge of each other via a trusted CA issuing their
 respective certificates.
@@ -462,9 +462,12 @@ tampered with in transit.
  <section anchor="auth-scheme" title="The 'Signature' HTTP Authentication Scheme">
 
   <t>
-The "signature" authentication scheme is based on the model that the client must
+The "Signature" authentication scheme is based on the model that the client must
 authenticate itself with a digital signature produced by either a private
-asymmetric key (e.g., RSA) or a shared symmetric key (e.g., HMAC).  The scheme
+asymmetric key (e.g., RSA) or a shared symmetric key (e.g., HMAC).
+  </t>
+  <t>
+The scheme
 is parameterized enough such that it is not bound to any particular key type or
 signing algorithm.  However, it does explicitly assume that clients can send an
 HTTP `Date` header.
@@ -483,7 +486,7 @@ Section 2: The Components of a Signature.
    </t>
 
    <t>
-The rest if this section uses the following HTTP request as an example.
+The rest of this section uses the following HTTP request as an example.
 
     <figure>
      <artwork>
@@ -505,17 +508,18 @@ Note that the use of the `Digest` header field is per
 target="http://tools.ietf.org/html/rfc3230#section-4.3.2">Section 4.3.2</eref>
 and is included merely as a demonstration of how an implementer could include
 information about the body of the message in the signature.
-The following sections also assume that the "rsa-key-1" keyId refers to a
-private key known to the client and a public key known to the server.
-The "hmac-key-1" keyId refers to key known to the client and server.
+The following sections also assume that the "rsa-key-1" keyId asserted by the
+client is an identifier meaningful to the server.
    </t>
 
    <section anchor="auth-isa" title="Initiating Signature Authorization">
 
     <t>
-A server may notify a client when a protected resource could be accessed by
-authenticating itself to the server. To initiate this process, the server
-will request that the client authenticate itself via a 401 response code. The
+A server may notify a client when a resource is protected by requiring a signature,
+To initiate this process, the server
+will request that the client authenticate itself via a
+<eref target="https://tools.ietf.org/html/rfc7235#section-3.1">401 response
+</eref> code. The
 server may optionally specify which HTTP headers it expects to be signed
 by specifying the `headers` parameter in the WWW-Authenticate header.
 For example:
@@ -608,9 +612,18 @@ content-length: 18
  <section anchor="sig" title="The 'Signature' HTTP Header">
 
   <t>
-The "signature" HTTP Header is based on the model that the sender must
-authenticate itself with a digital signature produced by either a private
-asymmetric key (e.g., RSA) or a shared symmetric key (e.g., HMAC).  The scheme
+The "Signature" HTTP Header allows the the sender to add a signature
+to a HTTP message (client request or server response) using either a private
+asymmetric key (e.g., RSA) or a shared symmetric key (e.g., HMAC), allowing 
+the receiver and/or any intermediate system to immediately or later
+verify the integrity of the message. When signed with a private key 
+it can also provide a measure of non-repudiation. The "Signature" scheme
+can also be used by (typically) a client for authentication similar
+to the purpose of the
+<xref target="auth-scheme">'Signature' HTTP Authentication Scheme</xref>
+  </t>
+  <t>
+The scheme
 is parameterized enough such that it is not bound to any particular key type or
 signing algorithm.  However, it does explicitly assume that senders can send an
 HTTP `Date` header.
@@ -648,9 +661,8 @@ Content-Length: 18
    </t>
 
    <t>
-The following sections assume that the "rsa-key-1" keyId refers to a
-private key known to the client and a public key known to the server.
-The "hmac-key-1" keyId refers to key known to the client and server.
+The following sections assume that the "rsa-key-1" keyId asserted by the
+client is an identifier meaningful to the server.
    </t>
 
    <section anchor="sig-rsa-example" title="RSA Example">

--- a/index.xml
+++ b/index.xml
@@ -164,7 +164,7 @@ verify that a message was signed by that entity.
    <t>
 When optionally combined with asymmetric keys associated with an
 identity, this specification can also enable authentication of a client and
-server with or without no prior knowledge of each other.
+server with or without prior knowledge of each other.
    </t>
   </section>
 
@@ -286,7 +286,7 @@ Even very minor changes would result in a signature which cannot be verified.
    </t>
    <t>
 This specification allows the sender to select which headers are meaningful
-by including their names the `headers` signature parameter. The headers
+by including their names in the `headers` signature parameter. The headers
 appearing in this parameter are then used to construct the intermediate
 Signature String, which is the data that is actually signed.
    </t>
@@ -516,7 +516,7 @@ client is an identifier meaningful to the server.
    <section anchor="auth-isa" title="Initiating Signature Authorization">
 
     <t>
-A server may notify a client when a resource is protected by requiring a signature,
+A server may notify a client when a resource is protected by requiring a signature.
 To initiate this process, the server
 will request that the client authenticate itself via a
 <eref target="https://tools.ietf.org/html/rfc7235#section-3.1">401 response

--- a/index.xml
+++ b/index.xml
@@ -113,38 +113,66 @@ are no techniques in this proposal that are novel beyond the previous art, it
 is useful to standardize a simple and cryptographically strong mechanism for
 digitally signing HTTP messages.
   </t>
+  <t>
+This specification presents two mechanisms with distinct purposes:
+    <list style="numbers">
+       <t>
+The "Signature" scheme which is intended primarily to allow a sender
+to assert the contents of the message sent are correct and have not been
+altered during transmission or storage in a way that alters the meaning expressed
+in the original message as signed. Any party reading the message (the verifier)
+may independently confirm the validity of the message signature. This scheme
+is agnostic to the client/server direction and can be used to verify the contents of
+either HTTP requests, HTTP reponses or both.
+       </t>
+       <t>
+The "Authorization" scheme which is intended primarily to allow a sender
+to assert an identity and request access to a resource or resources. This is
+typically used in authentication flows such as OAuth2, and as a consequence
+`Authorization` header is normally generated (and the message signed) by the
+HTTP client and the message verified by an HTTP service.
+       </t>
+     </list>
+  </t>
 
   <section anchor="intro-requests" title="Using Signatures in HTTP Requests">
    <t>
-It is common practice to protect sensitive website API functionality via
+It is common practice to protect sensitive website and API functionality via
 authentication mechanisms. Often, the entity accessing these APIs is a
 piece of automated software outside of an interactive human session. While
 there are mechanisms like OAuth and API secrets that are used to grant
 API access, each have their weaknesses such as unnecessary complexity
 for particular use cases or the use of shared secrets which may not be
-acceptable to an implementer.
+acceptable to an implementer. Shared secrets also prohibit any possibility
+for non-repudiation, while secure transports such as TLS do not provide
+for this at all.
    </t>
    <t>
-Digital signatures are widely used to provide authentication without
+Digital signatures are widely used to provide authentication and integrity
+assurances without
 the need for shared secrets. They also do not require a round-trip in
-order to authenticate the client. A server need only have a mapping between
-the key being used to sign the content and the authorized entity to
+order to authenticate the client, and allow the integrity of a message to
+be verified independently of the transport (e.g. TLS)
+A server need only have an understanding of the key (e.g. through
+a mapping between
+the key being used to sign the content and the authorized entity) to
 verify that a message was signed by that entity.
    </t>
    <t>
-This specification provides two mechanisms that can be used by a server
-to authenticate a client. The first is the 'Signature' HTTP Authentication
-Scheme, which may be used for interactive sessions. The second is the
-Signature HTTP Header, which is typically used by automated software
-agents.
+When optionally combined with keys in certificates issued
+via PKI, this specification can also enable authentication of a client and
+server with no prior knowledge of each other via a trusted CA issuing their
+respective certificates.
    </t>
   </section>
 
   <section anchor="intro-responses" title="Using Signatures in HTTP Responses">
    <t>
-For high security transactions, having an additional signature on the HTTP
-header allows a client to ensure that even if the transport channel has been
-compromised, that the content of the messages have not been compromised.
+For high security transactions, having a mechanism to sign HTTP responses
+allows a client to ensure that even if the transport channel has been
+compromised or intermediates alter the message by adding, removing or
+altering headers (even for benign operational reasons) that the content and meaning
+of the message has not been compromised.
 This specification provides a HTTP Signature Header mechanism that can be
 used by a client to authenticate the sender of a message and ensure that
 particular headers have not been modified in transit.
@@ -157,7 +185,8 @@ particular headers have not been modified in transit.
   <t>
 There are a number of components in a signature that are common between the
 'Signature' HTTP Authentication Scheme and the 'Signature' HTTP Header. This
-section details the components of a digital signature.
+section details the components of the digital signature paremeters common to
+both schemes.
   </t>
 
    <section anchor="params" title="Signature Parameters">
@@ -242,6 +271,24 @@ MUST be ignored.
 
    <section anchor="canonicalization" title="Signature String Construction">
 
+   <t>
+A signed HTTP message needs to be tolerant of some
+alterations during transmission
+as it goes through gateways, proxies and other entities. As such, the raw
+HTTP message transmitted by the signer, and the HTTP message received
+by the verifier may have undergone some changes, typically in the form of
+added, removed or altered headers. These changes are not normally under the
+control of the sender, and often the verifier. While these changes should not
+alter the meaning expressed by the sender this protocol allows for any sensitive
+or meaningful content changes to be detected by the verifier.
+   </t>
+   <t>
+As such, the signer cannot control which headers may appear in the message
+when it arrives at the verifier, and will explicitly indicate which headers were
+included in the signature via the `headers` signature parameter. The value of
+this parameter is used to construct the intermediate Signature String, which
+is the data that is actually signed.
+   </t>
    <t>
 In order to generate the string that is signed with a key, the client MUST use
 the values of each HTTP header field in the `headers` Signature parameter,

--- a/index.xml
+++ b/index.xml
@@ -171,14 +171,16 @@ respective certificates.
 
   <section anchor="intro-responses" title="Using Signatures in HTTP Responses">
    <t>
-For high security transactions, having a mechanism to sign HTTP responses
-allows a client to ensure that even if the transport channel has been
-compromised or intermediates alter the message by adding, removing or
-altering headers (even for benign operational reasons) that the content and meaning
-of the message has not been compromised.
-This specification provides a HTTP Signature Header mechanism that can be
-used by a client to authenticate the sender of a message and ensure that
-particular headers have not been modified in transit.
+HTTP messages are routinely altered as they traverse the infrastrcture of the
+Internet, for mostly benign reasons. Gateways and proxies add, remove and
+alter headers for operational reasons, so a sender cannot rely on the
+recipient receiving exactly the message transmitted.
+By allowing a sender to sign specified headers, and recipient or
+intermediate system can confirm that the original intent of the sender
+is preserved, and including a Digest header can also verify the message
+body is not modified. This allows any recipient to easily confirm both
+the sender's identity, and any incidental or malicious changes that alter
+the content or meaning of the message. 
    </t>
   </section>
 

--- a/index.xml
+++ b/index.xml
@@ -661,8 +661,8 @@ Content-Length: 18
    </t>
 
    <t>
-The following sections assume that the "rsa-key-1" keyId asserted by the
-client is an identifier meaningful to the server.
+The following sections assume that the "rsa-key-1" keyId provided by the
+signer is an identifier meaningful to the server.
    </t>
 
    <section anchor="sig-rsa-example" title="RSA Example">

--- a/index.xml
+++ b/index.xml
@@ -277,22 +277,19 @@ MUST be ignored.
    <section anchor="canonicalization" title="Signature String Construction">
 
    <t>
-A signed HTTP message needs to be tolerant of some
+A signed HTTP message needs to be tolerant of some trivial
 alterations during transmission
-as it goes through gateways, proxies, and other entities. As such, the raw
-HTTP message transmitted by the signer, and the HTTP message received
-by the verifier may have undergone some changes, typically in the form of
-added, removed or altered headers. These changes are not normally under the
-control of the sender, and often the verifier. While these changes should not
-alter the meaning expressed by the sender this protocol allows for any sensitive
-or meaningful content changes to be detected by the verifier.
+as it goes through gateways, proxies, and other entities. These changes are often
+of little consequence and very benign, but also often not visible to or
+detectable by either the sender or the recipient. Simply signing the entire
+message that was transmitted by the sender is therefore not feasible:
+Even very minor changes would result in a signature which cannot be verified.
    </t>
    <t>
-As such, the signer cannot control which headers may appear in the message
-when it arrives at the verifier, and will explicitly indicate which headers were
-included in the signature via the `headers` signature parameter. The value of
-this parameter is used to construct the intermediate Signature String, which
-is the data that is actually signed.
+This specification allows the sender to select which headers are meaningful
+by including their names the `headers` signature parameter. The headers
+appearing in this parameter are then used to construct the intermediate
+Signature String, which is the data that is actually signed.
    </t>
    <t>
 In order to generate the string that is signed with a key, the client MUST use
@@ -617,17 +614,22 @@ content-length: 18
  <section anchor="sig" title="The 'Signature' HTTP Header">
 
   <t>
-The "Signature" HTTP Header allows the the sender to add a signature
-to a HTTP message (client request or server response) using either a private
-asymmetric key (e.g., RSA) or a shared symmetric key (e.g., HMAC), allowing 
-the receiver and/or any intermediate system to immediately or later
-verify the integrity of the message. When signed with a private key 
-it can also provide a measure of non-repudiation. The "Signature" scheme
-can also be used by (typically) a client for authentication similar
-to the purpose of the
-<xref target="auth-scheme">'Signature' HTTP Authentication Scheme</xref>
+The "Signature" HTTP Header provides a mechanism to link the headers of a
+message (client request or server response) to a digital signature. By
+including the "Digest" header with a properly formatted digest,
+the message body can also be linked to the signature. The
+signature is generated and verified either using a shared secret (e.g. HMAC)
+or public/private keys (e.g. RSA, EC). This allows the receiver and/or any
+intermediate system to immediately or later verify the integrity of the
+message. When the signature is generated with a private key it can also
+provide a measure of non-repudiation, though a full implementation of a
+non-repudiatable statement is beyond the scope of this specification and
+highly dependent on implementation.
   </t>
   <t>
+The "Signature" scheme can also be
+used for authentication similar to the purpose of the
+<xref target="auth-scheme">'Signature' HTTP Authentication Scheme</xref>.
 The scheme
 is parameterized enough such that it is not bound to any particular key type or
 signing algorithm.  However, it does explicitly assume that senders can send an


### PR DESCRIPTION
This PR is primarily in response to https://github.com/w3c-dvcg/http-signatures/issues/13, but also provides some general clarifications and rewording of intent:

* Explicitly define Authorization and Signature schemes to differentiate them and propose distinct purposes
* Clarify some language that assumes the server is the verifier and client is the signer, to make the spec more portable and usable by both
* Highlight this spec is useful for both website and API, not just API
* Highlight the possibility of unknown parties to perform dentification via a trusted CA
* Highlight RSA's ability to provide non-repudiation over shared secrets and most transports
* Explain why message (header) may be altered in transit and why signature string is useful over signing the entire message
* Some language in Signature chapter seem to cater exclusively or dominantly to authorisation and not general-purpose digital signatures
* Remove bias towards client signing and server verifying
* Highlight benefits of PKI for non-repudation
* Generalise language on keyId (meaningful to server, not necessarily known to server)
* typos