### PR TITLE
Minor fixes - parameter delimiters, urls, typos

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -580,7 +580,7 @@ target="https://tools.ietf.org/html/rfc7230#section-3.2">
 Section 3.2</eref>) where the "field-name" is "Signature", and the "field-value"
 contains one or more "auth-param"s (as defined in
 <xref target="RFC7235">RFC 7235</xref>, <eref
-target="https://tools.ietf.org/html/rfc7235#section-4.1">
+target="https://tools.ietf.org/html/rfc7235#section-2.1">
 Section 4.1</eref>) where the "auth-param" parameters meet the requirements
 listed in Section 2.1: Signature Parameters. Each instance of "auth-param"
 is separated by an ASCII comma.

--- a/index.xml
+++ b/index.xml
@@ -436,7 +436,7 @@ Section 2: The Components of a Signature.
    </t>
 
    <t>
-The rest if this section uses the following HTTP request as an example.
+The rest of this section uses the following HTTP request as an example.
 
     <figure>
      <artwork>
@@ -585,7 +585,7 @@ listed in Section 2: The Components of a Signature.
    </t>
 
    <t>
-The rest if this section uses the following HTTP request as an example.
+The rest of this section uses the following HTTP request as an example.
 
     <figure>
      <artwork>

--- a/index.xml
+++ b/index.xml
@@ -432,7 +432,8 @@ The client is expected to send an Authorization header
 target="https://tools.ietf.org/html/rfc7235#section-2.1">
 Section 4.1</eref>) where the "auth-scheme" is "Signature" and the
 "auth-param" parameters meet the requirements listed in
-Section 2: The Components of a Signature.
+Section 2.1: Signature Parameters. Each instance of "auth-param"
+is separated by an ASCII comma.
    </t>
 
    <t>
@@ -581,7 +582,8 @@ contains one or more "auth-param"s (as defined in
 <xref target="RFC7235">RFC 7235</xref>, <eref
 target="https://tools.ietf.org/html/rfc7235#section-4.1">
 Section 4.1</eref>) where the "auth-param" parameters meet the requirements
-listed in Section 2: The Components of a Signature.
+listed in Section 2.1: Signature Parameters. Each instance of "auth-param"
+is separated by an ASCII comma.
    </t>
 
    <t>

--- a/index.xml
+++ b/index.xml
@@ -277,7 +277,7 @@ ASCII comma and an ASCII space `, `, and used in the order in which
 they will appear in the transmitted HTTP message.
          </t>
          <t>
-If the header value (after removing leading and trailing whitepspace)
+If the header value (after removing leading and trailing whitespace)
 is a zero-length string, the signature string line correlating with that header
 will simply be the (lowercased) header name, an ASCII colon `:`,
 and an ASCII space ` `.

--- a/index.xml
+++ b/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rfc PUBLIC "-//IETF//DTD RFC 2629//EN" "http://xml.resource.org/authoring/rfc2629.dtd" [
+<!DOCTYPE rfc PUBLIC "-//IETF//DTD RFC 2629//EN" "https://xml2rfc.tools.ietf.org/authoring/rfc2629.dtd" [
   <!ENTITY rfc2119 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
   <!ENTITY rfc2617 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2617.xml">
   <!ENTITY rfc3230 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3230.xml">
@@ -179,7 +179,7 @@ of keys and assignment of `keyId` is out of scope for this document.
      <t>
 REQUIRED.  The `signature` parameter is a base 64 encoded digital signature,
 as described in <xref target="RFC4648">RFC 4648</xref>,
-<eref target="http://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
+<eref target="https://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
 The client uses the `algorithm` and `headers` signature parameters to form a
 canonicalized `signing string`.  This `signing string` is then signed with the
 key associated with `keyId` and the algorithm corresponding to `algorithm`.
@@ -268,7 +268,7 @@ name followed with an ASCII colon `:`, an ASCII space ` `, and the header
 field value. Leading and trailing optional whitespace (OWS) in the header field
 value MUST be omitted (as specified in
 <xref target="RFC7230">RFC7230</xref>,
-<eref target="http://tools.ietf.org/html/rfc7230#section-3.2.4">Section 3.2.4</eref>).
+<eref target="https://tools.ietf.org/html/rfc7230#section-3.2.4">Section 3.2.4</eref>).
        <list style="numbers">
          <t>
 If there are multiple instances of the same header field, all header field
@@ -327,7 +327,7 @@ For the HTTP request headers above, the corresponding signature string is:
 host: example.org
 date: Tue, 07 Jun 2014 20:51:35 GMT
 cache-control: max-age=60, must-revalidate
-x-emptyheader: 
+x-emptyheader:
 x-example: Example header with some whitespace.
      </artwork>
     </figure>
@@ -361,7 +361,7 @@ signal to the application that the data associated with `keyId` is an
 RSA Private Key (as defined in <xref target="RFC3447">RFC 3447</xref>), the
 signature string hashing function is SHA-256, and the signing
 algorithm is the one defined in <xref target="RFC3447">RFC 3447</xref>,
-Section <eref target="http://tools.ietf.org/html/rfc3447#section-8.2.1">
+Section <eref target="https://tools.ietf.org/html/rfc3447#section-8.2.1">
 Section 8.2.1</eref>. The result of the signature creation algorithm
 specified in <xref target="RFC3447">RFC 3447</xref> should result in a
 binary string, which is then base 64 encoded and placed into the
@@ -402,7 +402,7 @@ express a RSA Public Key (as defined in <xref target="RFC3447">RFC 3447</xref>),
 the signature string hashing function of SHA-256, and the `signature`
 verification algorithm to use to verify the signature is the one defined in
 <xref target="RFC3447">RFC 3447</xref>, Section <eref
-target="http://tools.ietf.org/html/rfc3447#section-8.2.2">
+target="https://tools.ietf.org/html/rfc3447#section-8.2.2">
 Section 8.2.2</eref>. The result of the signature verification algorithm
 specified in <xref target="RFC3447">RFC 3447</xref> should result in a
 successful verification unless the headers protected by the signature were
@@ -429,7 +429,7 @@ HTTP `Date` header.
 The client is expected to send an Authorization header
 (as defined in
 <xref target="RFC7235">RFC 7235</xref>, <eref
-target="http://tools.ietf.org/html/draft-ietf-rfc7235-auth-25#section-4.1">
+target="https://tools.ietf.org/html/rfc7235#section-2.1">
 Section 4.1</eref>) where the "auth-scheme" is "Signature" and the
 "auth-param" parameters meet the requirements listed in
 Section 2: The Components of a Signature.
@@ -455,7 +455,7 @@ Content-Length: 18
    <t>
 Note that the use of the `Digest` header field is per
 <xref target="RFC3230">RFC 3230</xref>, <eref
-target="http://tools.ietf.org/html/rfc3230#section-4.3.2">Section 4.3.2</eref>
+target="https://tools.ietf.org/html/rfc3230#section-4.3.2">Section 4.3.2</eref>
 and is included merely as a demonstration of how an implementer could include
 information about the body of the message in the signature.
 The following sections also assume that the "rsa-key-1" keyId refers to a
@@ -575,11 +575,11 @@ HTTP `Date` header.
 The sender is expected to transmit a header
 (as defined in
 <xref target="RFC7230">RFC 7230</xref>, <eref
-target="http://tools.ietf.org/html/rfc7230#section-3.2">
+target="https://tools.ietf.org/html/rfc7230#section-3.2">
 Section 3.2</eref>) where the "field-name" is "Signature", and the "field-value"
 contains one or more "auth-param"s (as defined in
 <xref target="RFC7235">RFC 7235</xref>, <eref
-target="http://tools.ietf.org/html/rfc7235#section-4.1">
+target="https://tools.ietf.org/html/rfc7235#section-4.1">
 Section 4.1</eref>) where the "auth-param" parameters meet the requirements
 listed in Section 2: The Components of a Signature.
    </t>


### PR DESCRIPTION
- Resolves https://github.com/w3c-dvcg/http-signatures/issues/17
- Explicitly defines inter-parameter delimeter as a comma (weird that was never there) in Signature and Authorization chapters
- Update links to https (since they're redirecting anyway) and some uri updates
- Typos