### PR TITLE
Fix definition of rsa-sha256 to match previous versions

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -1147,7 +1147,7 @@ Canonicalization Algorithm: [RFC_THIS_DOCUMENT],
 Hash Algorithm: <xref target="RFC6234">RFC 6234</xref>,
 SHA-256 (SHA-2 with 256-bits of digest output)<vspace/>
 Digital Signature Algorithm:
-  <xref target="RFC8017">RFC 8017</xref>,  Section 8.1: RSASSA-PSS<vspace/>
+  <xref target="RFC8017">RFC 8017</xref>,  Section 8.2: RSASSA-PKCS1-v1_5<vspace/>
    </t>
    <t>
 Algorithm Name: hmac-sha256<vspace/>


### PR DESCRIPTION
The definition of the `rsa-sha256` algorithm in Draft 11 specifies digital signature algorithm to be "RSASSA-PSS", however, up until Draft 10, `rsa-sha256` referenced [Section 3.3.2 of RFC 6376][https://tools.ietf.org/html/rfc6376#section-3.3.2], which specifies PKCS#1 version 1.5 as the signature algorithm.

In the interest of full backwards compatibility, the definition of `rsa-sha256` has been modified to reference PKCS#1 version 1.5 as the signature algorithm.