### PR TITLE
Correct typos & Documentation of the algorithm parameter

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -239,7 +239,7 @@ as described in <xref target="RFC4648">RFC 4648</xref>,
 <eref target="https://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
 The client uses the `headers` Signature Parameter to form a
 canonicalized `signing string`. This `signing string` is then signed using the key
-from the keyId and the digital signature algorithm specified in the key's metadata.
+associated with the `keyId` according to its digital signature algorithm.
 The `signature` parameter is then set to the base 64 encoding of the signature.
      </t>
     </section>

--- a/index.xml
+++ b/index.xml
@@ -191,7 +191,7 @@ server with or without prior knowledge of each other.
 
   <section anchor="intro-responses" title="Using Signatures in HTTP Responses">
    <t>
-HTTP messages are routinely altered as they traverse the infrastrcture of the
+HTTP messages are routinely altered as they traverse the infrastructure of the
 Internet, for mostly benign reasons. Gateways and proxies add, remove and
 alter headers for operational reasons, so a sender cannot rely on the
 recipient receiving exactly the message transmitted.

--- a/index.xml
+++ b/index.xml
@@ -277,7 +277,7 @@ Header such as when operating in certain web browser environments.
     <section anchor="expires" title="expires">
      <t>
 OPTIONAL.  The `expires` field expresses when the signature ceases to be valid.
-The value MUST be a Unix timestamp integer value. A signatures with an
+The value MUST be a Unix timestamp integer value. A signature with an
 `expires` timestamp value that is in the past MUST NOT be processed. Using
 a Unix timestamp simplifies processing and avoid timezone management existing
 in RFC3339. Subsecod precision is allowed using decimal notation.

--- a/index.xml
+++ b/index.xml
@@ -277,7 +277,7 @@ Header such as when operating in certain web browser environments.
     <section anchor="expires" title="expires">
      <t>
 OPTIONAL.  The `expires` field expresses when the signature ceases to be valid.
-The value MUST be a Unix timestamp integer value. A signatures with a
+The value MUST be a Unix timestamp integer value. A signatures with an
 `expires` timestamp value that is in the past MUST NOT be processed. Using
 a Unix timestamp simplifies processing and avoid timezone management existing
 in RFC3339. Subsecod precision is allowed using decimal notation.

--- a/index.xml
+++ b/index.xml
@@ -237,9 +237,9 @@ employ when creating or verifying signatures.
 REQUIRED.  The `signature` parameter is a base 64 encoded digital signature,
 as described in <xref target="RFC4648">RFC 4648</xref>,
 <eref target="https://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
-The client uses the `algorithm` and `headers` Signature Parameters to form a
-canonicalized `signing string`.  This `signing string` is then signed with the
-key associated with `keyId` and the algorithm corresponding to `algorithm`.
+The client uses the `headers` Signature Parameters to form a
+canonicalized `signing string`. This `signing string` is then signed using the key
+from the keyId and the digital signature algorithm specified in the key's metadata.
 The `signature` parameter is then set to the base 64 encoding of the signature.
      </t>
     </section>

--- a/index.xml
+++ b/index.xml
@@ -237,7 +237,7 @@ employ when creating or verifying signatures.
 REQUIRED.  The `signature` parameter is a base 64 encoded digital signature,
 as described in <xref target="RFC4648">RFC 4648</xref>,
 <eref target="https://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
-The client uses the `headers` Signature Parameters to form a
+The client uses the `headers` Signature Parameter to form a
 canonicalized `signing string`. This `signing string` is then signed using the key
 from the keyId and the digital signature algorithm specified in the key's metadata.
 The `signature` parameter is then set to the base 64 encoding of the signature.

--- a/index.xml
+++ b/index.xml
@@ -237,7 +237,7 @@ employ when creating or verifying signatures.
 REQUIRED.  The `signature` parameter is a base 64 encoded digital signature,
 as described in <xref target="RFC4648">RFC 4648</xref>,
 <eref target="https://tools.ietf.org/html/rfc4648#section-4">Section 4</eref>.
-The client uses the `headers` Signature Parameter to form a
+The client uses the `algorithm` and `headers` Signature Parameters to form a
 canonicalized `signing string`. This `signing string` is then signed using the key
 associated with the `keyId` according to its digital signature algorithm.
 The `signature` parameter is then set to the base 64 encoding of the signature.


### PR DESCRIPTION
Corrects Issue:
https://github.com/w3c-dvcg/http-signatures/issues/59

Corrects 2 typos and one documentation issue.

> The client uses the `algorithm` and `headers` Signature Parameters to form a
> canonicalized `signing string`.  This `signing string` is then signed with the
> key associated with `keyId` and the algorithm corresponding to `algorithm`.

> The client uses the `headers` Signature Parameter to form a
> canonicalized `signing string`. This `signing string` is then signed using the key
> from the keyId and the digital signature algorithm specified in the key's metadata.