### PR TITLE
Removed adding the content of the HTTP message in creating the signature string.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -456,7 +456,7 @@ x-example: Example header with some whitespace.
 In order to create a signature, a client MUST:
     <list style="numbers">
      <t>
-Use the headers value to create the signature string.
+Use the HTTP headers values to create the signature string.
      </t>
      <t>
 Use the key associated with `keyId` to generate a digital signature on the

--- a/index.xml
+++ b/index.xml
@@ -456,8 +456,7 @@ x-example: Example header with some whitespace.
 In order to create a signature, a client MUST:
     <list style="numbers">
      <t>
-Use the `headers` and `algorithm` values as well as the contents of the HTTP
-message, to create the signature string.
+Use the headers value to create the signature string.
      </t>
      <t>
 Use the key associated with `keyId` to generate a digital signature on the


### PR DESCRIPTION
The spec doesn't mention adding the content of the message to the signature string anywhere, and the algorithm isn't used to make the signature string.
Fixes #54 