### PR TITLE
Fix: #63. forbid erroneously duplicate parameters

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -314,7 +314,7 @@ a `headers` parameter at all.
    <section anchor="ambiguity" title="Ambiguous Parameters">
     <t>
 If any of the parameters listed above are erroneously duplicated in the
-associated header field, then the last parameter defined MUST be used. Any
+associated header field, then the the signature MUST NOT be processed. Any
 parameter that is not recognized as a parameter, or is not well-formed,
 MUST be ignored.
     </t>


### PR DESCRIPTION
## This PR

- forbids validating signatures with erroneusly duplicate parameters.
- erroneously duplicate parameters must be considered invalid.

eg. the following will be invalid

```
    Signature: keyId="foo", keyId="bar",...  
```

## The current specs instead:

- forces the receiver to accept erroneously duplicated parameters;
- complicates the implementation, as `Signature` parameters don't map to a plain old dictionary

## Fix

#63 