### PR TITLE
Fix: #67. Forbid zero-length Signature.headers.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -300,10 +300,8 @@ during <xref target="canonicalization">Signature String Construction</xref>
 used during signing and verifying.
            </t>
            <t>
-A `headers` parameter value without any headers MAY be provided,
-but since it results in a signature of an empty string it is of almost no
-utility and SHOULD NOT be used. This is distinct from not specifying
-a `headers` parameter at all.
+A zero-length `headers` parameter value MUST NOT be used,
+since it results in a signature of an empty string. 
            </t>
         </list>
      </t>


### PR DESCRIPTION
## This PR

Forbids signing a blank string.

You should sign at least one HTTP header, or the signature could be used multiple times (replay attack).