### PR TITLE
Sign content-type when digest is used. #36

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -615,7 +615,7 @@ The authorization header and signature would be generated as:
     <figure>
      <artwork>
 Authorization: Signature keyId="rsa-key-1",algorithm="hs2019",
-  headers="(request-target) (created) host digest content-length",
+  headers="(request-target) (created) host digest content-type content-length",
   signature="Base64(RSA-SHA512(signing string))"</artwork>
     </figure>
    </t>
@@ -628,6 +628,7 @@ The client would compose the signing string as:
 (created): 1402174295
 host: example.org\n
 digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=\n
+content-type: text/html\n
 content-length: 18</artwork>
     </figure>
 Note that the '\n' symbols above are included to demonstrate where the new
@@ -642,7 +643,7 @@ be generated as:
     <figure>
      <artwork>
 Authorization: Signature keyId="rsa-key-1",algorithm="hs2019",
-headers="(request-target) (created) host digest content-length",
+headers="(request-target) (created) host digest content-type content-length",
 signature="Base64(RSA-SHA512(signing string))"</artwork>
     </figure>
    </t>
@@ -656,7 +657,7 @@ authorization header and signature would be generated as:
     <figure>
      <artwork>
 Authorization: Signature keyId="hmac-key-1",algorithm="hs2019",
-headers="(request-target) (created) host digest content-length",
+headers="(request-target) (created) host digest content-type content-length",
 signature="Base64(HMAC-SHA512(signing string))"
      </artwork>
     </figure>
@@ -672,6 +673,7 @@ signing string in the same way as the RSA Example above:
 (created): 1402174295
 host: example.org\n
 digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=\n
+content-type: text/html\n
 content-length: 18
      </artwork>
     </figure>
@@ -750,7 +752,7 @@ The signature header and signature would be generated as:
 Signature: keyId="rsa-key-1",algorithm="hs2019",
   created=1402170695, expires=1402170995,
   headers="(request-target) (created) (expires)
-    host date digest content-length",
+    host date digest content-type content-length",
   signature="Base64(RSA-SHA256(signing string))"</artwork>
     </figure>
    </t>
@@ -764,6 +766,7 @@ The client would compose the signing string as:
 (expires): 1402170995
 host: example.org\n
 digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=\n
+content-type: text/html\n
 content-length: 18</artwork>
     </figure>
 Note that the '\n' symbols above are included to demonstrate where the new
@@ -778,7 +781,7 @@ be generated as:
     <figure>
      <artwork>
 Signature: keyId="rsa-key-1",algorithm="hs2019",created=1402170695,
-  headers="(request-target) (created) host digest content-length",
+  headers="(request-target) (created) host digest content-type content-length",
   signature="Base64(RSA-SHA512(signing string))"</artwork>
     </figure>
    </t>
@@ -792,7 +795,7 @@ authorization header and signature would be generated as:
     <figure>
      <artwork>
 Signature: keyId="hmac-key-1",algorithm="hs2019",created=1402170695,
-  headers="(request-target) (created) host digest content-length",
+  headers="(request-target) (created) host digest content-type content-length",
   signature="Base64(HMAC-SHA512(signing string))"</artwork>
     </figure>
    </t>
@@ -807,6 +810,7 @@ in the same way as the RSA Example above:
 (created): 1402170695
 host: example.org\n
 digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=\n
+content-type: text/html\n
 content-length: 18
      </artwork>
     </figure>


### PR DESCRIPTION
## This PR

Fixes #36 explicitly signing `Content-Type` when the `Digest HTTP Header` is used.

## Note

We are not forced to use `Digest` when sending authentication requests, though it helps 
increasing the cardinality of the signature input. 