### PR TITLE
Forbid referring to zero-length header values.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -390,10 +390,8 @@ ASCII comma and an ASCII space `, `, and used in the order in which
 they will appear in the transmitted HTTP message.
          </t>
          <t>
-If the header value (after removing leading and trailing whitespace)
-is a zero-length string, the signature string line correlating with that header
-will simply be the (lowercased) header name, an ASCII colon `:`,
-and an ASCII space ` `.
+A header field MUST NOT refer to a header value that is a zero-length string
+(after removing leading and trailing whitespace).
          </t>
          <t>
 Any other modification to


### PR DESCRIPTION
The reason behind this PR is the following:

During HTTP signature test suite creation I found passing an HTTP Message with a header that's value is only white spaces results in the header being dropped. This means that the existing rule to simply use the header field a colon and a white space results in test failure as when it goes to look for the header value there is no value for that header field. 

This is a fix for one of the issues from: https://github.com/w3c-dvcg/http-signatures/issues/81

_If other implementors could test how their HTTP message parsers treat headers with zero-length string values or white space only values that would help_.

I tried this in express this morning and it unfortunately looks like the HTTP parser I am using for the binary in the tests is the outlier. Express did turn headers with zero length strings into what the specification expects.