### PR TITLE
Project Principles, Readme & Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,9 @@ compliance would introduce security concerns.
   be able to ignore any signature header safely.
 
 - The specification should avoid wherever possible any aspects requiring
-  negotiation or agreement between parties. Out-of-band specification should
-  be relied upon unless critical to security or functionality.
+  negotiation or agreement between parties. Out-of-band specification of
+  permissible parameters, keys etc should be relied upon unless critical to
+  security or functionality.
 
 - This specification must not apply new interpretations to existing
   concepts and terms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,17 @@ compliance would introduce security concerns.
   choices on how it can/should be used, while also specific enough that
   implementers can unambiguously understand how to produce and verify a
   signature safely and effectively.
+
+# What You See is What You Sign
+
+- Signatures serve an immediate purpose to authenticate and verify a
+  HTTP message at the point it is received and processed, so the protocol
+  should provide a mechanism to determine the timeliness of a signature
+
+- Signatures may serve an after-the-fact purpose to be able to verify that a
+  request or response was properly verified at some point in the past
+  (auditing)
+
+- To serve both the above purposes, signatures should be verifiable given
+  the information available at that time. Signatures should not rely on
+  information not present in a given message except for the secrets used.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+Signing HTTP Messages Contribution Guide
+========================================
+
+This specification is under active development, and the more participants
+we get the better for everyone. We want this specification to be a
+useful addition to the ecosystem of the Internet, so it needs to be
+readable, useful and effective.
+
+You can contribute to the project by looking at the
+[open issues](https://github.com/w3c-dvcg/http-signatures/issues) and join
+a discussion, or raise a new issue if you have a bug or new feature
+suggestion.
+
+First though, take a look at the guiding principles of the project:
+
+# Principles
+
+## Platform, Language & Transport neutrality
+
+This protocol is meant to provide a technical mechanism to produce and
+verify digital signatures of HTTP Messages in a platform-agnostic way
+
+- The protocol should not be overly specific with a particular implementation,
+  language, runtime or framework. The protocol should work the same way for
+  all.
+
+- The protocol must be independent of the transport and any security
+  mechanisms implemented there e.g. client & server TLS certificates.
+
+## Simple and Compatible
+
+This protocol should comply fully with the state of HTTP except where
+compliance would introduce security concerns. Don't re-interperet existing
+definitions or protocols or modify the meanings of established ideas.
+
+- If HTTP does or permits something, this protocol should allow it to be signed.
+  - This means we also support things that are there for legacy reasons or
+  perhaps don't seem like an obviously good idea, unless there is a good
+  (especially security) reason not to.
+  
+- Any implementation that does not recognise or support this protocl should
+  be able to ignore any signature header safely.
+
+- The specification should avoid wherever possible any aspects requiring negotiation or agreement on parameters.
+
+- This specification must not apply new interpretations to existing concepts and terms
+
+
+From Manu:
+
+* Don't break the ecosystem, stay backwards compatible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ First though, take a look at the guiding principles of the project:
 This protocol is meant to provide a technical mechanism to produce and
 verify digital signatures of HTTP Messages in a platform-agnostic way
 
-- The protocol should not be overly specific with a particular implementation,
-  language, runtime or framework. The protocol should work the same way for
-  all.
+- The protocol should not be overly specific with a particular
+  implementation, language, runtime or framework.
+  The protocol should work the same way for all.
 
 - The protocol must be independent of the transport and any security
   mechanisms implemented there e.g. client & server TLS certificates.
@@ -30,22 +30,21 @@ verify digital signatures of HTTP Messages in a platform-agnostic way
 ## Simple and Compatible
 
 This protocol should comply fully with the state of HTTP except where
-compliance would introduce security concerns. Don't re-interperet existing
-definitions or protocols or modify the meanings of established ideas.
+compliance would introduce security concerns.
 
-- If HTTP does or permits something, this protocol should allow it to be signed.
+- If HTTP does or permits something, this protocol should allow it to be
+  signed.
+
   - This means we also support things that are there for legacy reasons or
-  perhaps don't seem like an obviously good idea, unless there is a good
-  (especially security) reason not to.
-  
+    perhaps don't seem like an obviously good idea, unless there is a good
+    (especially security) reason not to.
+
 - Any implementation that does not recognise or support this protocl should
   be able to ignore any signature header safely.
 
-- The specification should avoid wherever possible any aspects requiring negotiation or agreement on parameters.
+- The specification should avoid wherever possible any aspects requiring
+  negotiation or agreement between parties. Out-of-band specification should
+  be relied upon unless critical to security or functionality.
 
-- This specification must not apply new interpretations to existing concepts and terms
-
-
-From Manu:
-
-* Don't break the ecosystem, stay backwards compatible.
+- This specification must not apply new interpretations to existing
+  concepts and terms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ compliance would introduce security concerns.
     perhaps don't seem like an obviously good idea, unless there is a good
     (especially security) reason not to.
 
-- Any implementation that does not recognise or support this protocl should
+- Any implementation that does not recognise or support this protocol should
   be able to ignore any signature header safely.
 
 - The specification should avoid wherever possible any aspects requiring

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ verify digital signatures of HTTP Messages in a platform-agnostic way
 
 ## Simple and Compatible
 
-This protocol should comply fully with the state of HTTP except where
+- This specification should comply fully with the state of HTTP except where
 compliance would introduce security concerns.
 
-- If HTTP does or permits something, this protocol should allow it to be
+  - If HTTP does or permits something, this protocol should allow it to be
   signed.
 
-  - This means we also support things that are there for legacy reasons or
+  - This means we also support things that present for legacy reasons or
     perhaps don't seem like an obviously good idea, unless there is a good
     (especially security) reason not to.
 
@@ -48,3 +48,9 @@ compliance would introduce security concerns.
 
 - This specification must not apply new interpretations to existing
   concepts and terms
+
+- This specification should be simple enough for non-specialists to
+  understand and recognise the core concepts, allowing them to make informed
+  choices on how it can/should be used, while also specific enough that
+  implementers can unambiguously understand how to produce and verify a
+  signature safely and effectively.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ First though, take a look at the guiding principles of the project:
 ## Platform, Language & Transport neutrality
 
 This protocol is meant to provide a technical mechanism to produce and
-verify digital signatures of HTTP Messages in a platform-agnostic way
+verify the origin and integrity of HTTP Messages in a platform-agnostic way
 
 - The protocol should not be overly specific with a particular
   implementation, language, runtime or framework.
@@ -26,6 +26,11 @@ verify digital signatures of HTTP Messages in a platform-agnostic way
 
 - The protocol must be independent of the transport and any security
   mechanisms implemented there e.g. client & server TLS certificates.
+
+- While the protocol only protects headers, payload integrity can be assured
+  through inrorporation of other mechanisms such as Digest header. The
+  protocol should not be overly prescriptive of specific techniques but
+  illustrate how implementations might use them to achieve these goals.
 
 ## Simple and Compatible
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ compliance would introduce security concerns.
 # What You See is What You Sign
 
 - Signatures serve an immediate purpose to authenticate and verify a
-  HTTP message at the point it is received and processed, so the protocol
+  HTTP message as it is processed by intermediaries and eventually received
+  by the target system (client or server), so the protocol
   should provide a mechanism to determine the timeliness of a signature
 
 - Signatures may serve an after-the-fact purpose to be able to verify that a

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ However there is no accepted mechanism to provide protection to the HTTP
 message as a whole, and especially within a single HTTP request/response
 session.
 
-By allowing senders to add a signature header to a message, any HTTP message
-can be read the signature verified to ensure integrity, verify the origin
-of a message, and detect tampering.
+With this specification, a sender (HTTP client or server) can attach a
+signature to any HTTP message, allowing any recipient to read the signature
+and verify the integrity of the message and detect tampering.
 
 # Operation
 
@@ -28,14 +28,14 @@ The underlying mechanisms of the protocol are rather simple:
 
 - A set of a HTTP message's headers are "canonicalized" (transformed to a
   standard representation) into a single string
-- The string is digitally signed with either a shared secret, or a private
-  key
+- The canonicalized string (hash) is digitally signed with either a shared
+  secret, or a private key
 - The digital signature is included as a header in the message it signed,
   along with parameters explaining how the signature was formulated
 
-Using the above method, signature and parameters any application can read
-the HTTP message and signature header, along with either the same shared
-secret or the corresponding public key as necessary to verify:
+Using the canonicalization method and the provided header, any application
+reading the HTTP message, and (using either the shared secret or the
+corresponding public key as necessary) verify:
 
 - The integrity of the message (it has not been altered since being signed)
 - The identity of the signer if the key can be associated with the identity
@@ -45,7 +45,7 @@ The protocol, operates in one of two modes, though the core mechanism of
 generating and verifiying signatures is the same in both:
 
 - The `Signature` header, which can add a signature to any HTTP message
-  (request or respnse)
+  (request or response)
 - The "Signature HTTP Authentication Scheme" which is used in HTTP requests
   to authorize access to a resource.
 
@@ -62,16 +62,19 @@ This is a standard representation for IETF standards, which is then rendered
 in other representations including text, HTML and PDF as needed.
 
 The Python tool [XML Copy Editor](http://xml-copy-editor.sourceforge.net/)
-can be used to edit and validate the XML file in a GUI.
+can be used to edit and validate the XML file in a GUI, while the tool
+``xml2rfc`` is used to both check the integrity of the edited XML file and
+render it in various formats locally. The tool is available
+[online](https://xml2rfc.tools.ietf.org/) and as
+a [Python package](https://pypi.org/project/xml2rfc/).
 
 # Copyright Notice
 
-   Copyright (c) 2019 IETF Trust and the persons identified as the
-   document authors.  All rights reserved.
+Copyright (c) 2019 IETF Trust and the persons identified as the
+document authors.  All rights reserved.
 
-   This document is subject to BCP 78 and the IETF Trust's Legal
-   Provisions Relating to IETF Documents
-   (https://trustee.ietf.org/license-info) in effect on the date of
-   publication of this document.  Please review these documents
-   carefully, as they describe your rights and restrictions with respect
-   to this document.
+This document is subject to BCP 78 and the [IETF Trust's Legal Provisions
+Relating to IETF Documents](https://trustee.ietf.org/license-info) in
+effect on the date of publication of this document.  Please review these
+documents carefully, as they describe your rights and restrictions with
+respect to this document.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+Signing HTTP Messages
+=====================
+
+This project is the main work area for the [Signing HTTP Messages draft
+standard](https://datatracker.ietf.org/doc/draft-cavage-http-signatures/).
+
+The standard aims to provide a way for senders of HTTP messages - both
+requests and respnses - to digitally sign specified headers in a manner
+compatible with existing HTTP implementations.
+
+# Motivation
+
+Many schemes exist to protect data objects that may be transported as the
+payload of a HTTP message. These include JWS, XML Signatures, and detached
+sgnatures in multipart messages using e.g. GPG.
+
+However there is no accepted mechanism to provide protection to the HTTP
+message as a whole, and especially within a single HTTP request/response
+session.
+
+By allowing senders to add a signature header to a message, any HTTP message
+can be read the signature verified to ensure integrity, verify the origin
+of a message, and detect tampering.
+
+# Operation
+
+The underlying mechanisms of the protocol are rather simple:
+
+- A set of a HTTP message's headers are "canonicalized" (transformed to a
+  standard representation) into a single string
+- The string is digitally signed with either a shared secret, or a private
+  key
+- The digital signature is included as a header in the message it signed,
+  along with parameters explaining how the signature was formulated
+
+Using the above method, signature and parameters any application can read
+the HTTP message and signature header, along with either the same shared
+secret or the corresponding public key as necessary to verify:
+
+- The integrity of the message (it has not been altered since being signed)
+- The identity of the signer if the key can be associated with the identity
+  of the signer
+
+The protocol, operates in one of two modes, though the core mechanism of
+generating and verifiying signatures is the same in both:
+
+- The `Signature` header, which can add a signature to any HTTP message
+  (request or respnse)
+- The "Signature HTTP Authentication Scheme" which is used in HTTP requests
+  to authorize access to a resource.
+
+# Contributing
+
+This standard is under active development, and contributions are welcome.
+
+Please review the [Contributing Guide](./CONTRIBUTING.md) to see how you
+can participate, as well as learn about the principles of the project to
+help the process along.
+
+The specification itself is documented in the file [index.xml](index.xml).
+This is a standard representation for IETF standards, which is then rendered
+in other representations including text, HTML and PDF as needed.
+
+The Python tool [XML Copy Editor](http://xml-copy-editor.sourceforge.net/)
+can be used to edit and validate the XML file in a GUI.
+
+# Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.


### PR DESCRIPTION
In order to help smooth out discussions I thought it useful to capture some [guiding principles](https://github.com/liamdennehy/http-signatures/blob/contributing/CONTRIBUTING.md#principles) for this specification. Hopefully these can be agreed on and used as a reference point for future and existing issues. This also captures the "tribal knowledge" formally, which I think is useful. Right now these are buried deep in some lengthy issue discussions.

To illustrate:

The issues on permitting or denying multiple "Signature" headers cannot be resolved until we first agree multiple header instances are ok in any case, and how to sign multiple instance headers depends on answering the same question. Since the HTTP RFCs are not particularly clear, we need to either be strict or tolerant in our interpretation, but it should at least be consistent. I have formulated the first bullet under the principle "[Simple and Compatible](https://github.com/liamdennehy/http-signatures/blob/contributing/CONTRIBUTING.md#simple-and-compatible)" with this in mind, hopefully in a way that does not cause controversy. 

I suggest opening new issues with the "project" tag for specific issues rather than going down the comments road here, and tagging this PR in those issues.